### PR TITLE
Support for blacklisting users

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -28,6 +28,7 @@ function Bot(options) {
   this.ircOptions = options.ircOptions;
   this.commandCharacters = options.commandCharacters || [];
   this.channels = _.values(options.channelMapping);
+  this.blacklist = options.blacklist || [];
 
   this.channelMapping = {};
 
@@ -160,7 +161,17 @@ Bot.prototype.isCommandMessage = function(message) {
   return this.commandCharacters.indexOf(message[0]) !== -1;
 };
 
+Bot.prototype.isBlacklistedUsername = function(username) {
+  return this.blacklist.indexOf(username) !== -1;
+}
+
 Bot.prototype.sendToIRC = function(message) {
+  var user = this.slack.getUserByID(message.user);
+  if (this.isBlacklistedUsername(user.name)) {
+    logger.debug('Discarding message from blacklisted user ' + user.name);
+    return;
+  }
+
   var channel = this.slack.getChannelGroupOrDMByID(message.channel);
   if (!channel) {
     logger.info('Received message from a channel the bot isn\'t in:',
@@ -173,8 +184,6 @@ Bot.prototype.sendToIRC = function(message) {
 
   logger.debug('Channel Mapping', channelName, this.channelMapping[channelName]);
   if (ircChannel) {
-    var user = this.slack.getUserByID(message.user);
-
     var text = this.parseText(message.getBody());
 
     if (this.isCommandMessage(text)) {
@@ -190,6 +199,10 @@ Bot.prototype.sendToIRC = function(message) {
 };
 
 Bot.prototype.sendToSlack = function(author, channel, text) {
+  if (this.isBlacklistedUsername(author)) {
+    logger.debug('Discarding message from blacklisted user ' + author);
+    return;
+  }
   var slackChannelName = this.invertedMapping[channel.toLowerCase()];
   if (slackChannelName) {
     var slackChannel = this.slack.getChannelGroupOrDMByName(slackChannelName);


### PR DESCRIPTION
Adds support to blackist messages from users on both ends. This is useful to block messages from bots or annoying users. To make use of this, add a "blacklist" option of type array to the configuration and fill it with the usernames to block.
